### PR TITLE
Sign .js release files in addition to .tar.gz files

### DIFF
--- a/nightly/lib/config.php
+++ b/nightly/lib/config.php
@@ -7,7 +7,11 @@ class Config {
   const BRANCH = 'master';
   const RELEASE_TAG_FORMAT = '/v[0-9]+(\.[0-9]+)*/';
 
+  // Auth token for sign_releases endpoint
   const SIGN_AUTH_TOKEN = 'CHANGEME';
+  // File types that should be GPG signed as part of GitHub releases
+  const SIGN_FILE_TYPES = '/\.(tar\.gz|js)$/';
+
   const GITHUB_TOKEN = 'CHANGEME';
   const CIRCLECI_TOKEN = 'CHANGEME';
 


### PR DESCRIPTION
Out of all the files in the releases (eg. https://github.com/yarnpkg/yarn/releases/tag/v0.20.3), only the tarball and the MSI are signed. The tarball is signed using GPG, and the MSI is signed using an Authenticode certificate. Additionally, the .deb is signed as part of the Debian repo, but the individual file on Github is not signed.

This PR updates the signing code to also sign the standalone `.js` files, so they can also be verified.

References https://github.com/yarnpkg/yarn/issues/2728
References https://github.com/nodejs/docker-node/issues/243