### PR TITLE
Add endpoint for CircleCI releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Available endpoints on `nightly.yarnpkg.com`:
 * `/latest-[type]-version` (eg. `/latest-tar-version`, `/latest-msi-version`): Returns the version number of the latest nightly build containing a file of this format. This is useful because the Windows and Linux builds are performed separately, so the version number of the latest MSI may differ from the other version numbers.
 * `/[type]-builds` (eg. `/tar-builds`, `/msi-builds`): Returns a list of all the nightly builds available for this type. Used on the nightly builds page (https://yarnpkg.com/en/docs/nightly).
 * `/release_appveyor`: Handles stable release builds from AppVeyor. Grabs the MSI from AppVeyor, Authenticode signs it, then uploads it to the GitHub release. Called as a webhook from the AppVeyor build
+* `/release_circleci`: Similar to `release_appveyor`, except for CircleCI builds. Called a webhook from the CircleCI build
 * `/sign_releases`: GPG signs all `.tar.gz` and `.js` files for all GitHub releases, attaching the signatures as `.asc` files to the GitHub releases
 
 Files in the `nightly` directory:

--- a/nightly/api/archive_appveyor.php
+++ b/nightly/api/archive_appveyor.php
@@ -6,9 +6,6 @@
 
 require(__DIR__.'/../lib/api-core.php');
 
-use Analog\Analog;
-
-Analog::handler(__DIR__.'/../logs/archive_appveyor.log');
 AppVeyor::validateWebhookAuth();
 
 $payload = json_decode(file_get_contents('php://input'));

--- a/nightly/api/archive_circleci.php
+++ b/nightly/api/archive_circleci.php
@@ -12,10 +12,6 @@
 
 require(__DIR__.'/../lib/api-core.php');
 
-use Analog\Analog;
-
-Analog::handler(__DIR__.'/../logs/archive_circleci.log');
-
 $build = CircleCI::getAndValidateBuildFromPayload();
 $artifacts = CircleCI::call(
   'project/github/%s/%s/%s/artifacts',

--- a/nightly/api/archive_circleci.php
+++ b/nightly/api/archive_circleci.php
@@ -13,15 +13,5 @@
 require(__DIR__.'/../lib/api-core.php');
 
 $build = CircleCI::getAndValidateBuildFromPayload();
-$artifacts = CircleCI::call(
-  'project/github/%s/%s/%s/artifacts',
-  Config::ORG_NAME,
-  Config::REPO_NAME,
-  $build->build_num
-);
-$urls = [];
-foreach ($artifacts as $artifact) {
-  $filename = basename($artifact->path);
-  $urls[$filename] = $artifact->url;
-}
+$urls = CircleCI::getArtifactsForBuild($build->build_num);
 ArtifactArchiver::archiveBuild($urls, $build->build_num);

--- a/nightly/api/release_appveyor.php
+++ b/nightly/api/release_appveyor.php
@@ -6,10 +6,8 @@
 
 require(__DIR__.'/../lib/api-core.php');
 
-use Analog\Analog;
 use GuzzleHttp\Client;
 
-Analog::handler(__DIR__.'/../logs/release_appveyor.log');
 AppVeyor::validateWebhookAuth();
 
 $payload = json_decode(file_get_contents('php://input'));

--- a/nightly/api/release_appveyor.php
+++ b/nightly/api/release_appveyor.php
@@ -58,17 +58,5 @@ $release = GitHub::getOrCreateRelease($tag);
 
 // Upload the file to the release
 $signed_filename = str_replace('-unsigned', '', $filename);
-$uri = new \Rize\UriTemplate\UriTemplate();
-$upload_url = $uri->expand(
-  $release->upload_url,
-  ['name' => $signed_filename]
-);
-$client->post($upload_url, [
-  'body' => fopen($signed_tempfile, 'r'),
-  'headers' => [
-    'Authorization' => 'token '.Config::GITHUB_TOKEN,
-    'Content-Type' => 'application/octet-stream',
-  ],
-]);
-
+GitHub::uploadReleaseArtifact($release, $signed_filename, $signed_tempfile)->wait();
 api_response('Published '.$signed_filename.' to '.$tag);

--- a/nightly/api/release_circleci.php
+++ b/nightly/api/release_circleci.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * A CircleCI webhook that pulls build artifacts from AppVeyor and deploys them
+ * to the GitHub release.
+ */
+
+require(__DIR__.'/../lib/api-core.php');
+set_time_limit(100);
+
+use GuzzleHttp\Promise;
+
+$build = CircleCI::getAndValidateBuildFromPayload();
+// Only publish tagged releases
+if (!preg_match(Config::RELEASE_TAG_FORMAT, $build->vcs_tag)) {
+  api_response(sprintf(
+    '[%s] Not publishing as release; this is not a release tag. branch=%s tag=%s',
+    $build->build_num,
+    $build->branch ?? '[none]',
+    $build->vcs_tag ?? '[none]'
+  ));
+}
+
+$artifacts = CircleCI::getArtifactsForBuild($build->build_num);
+$tempdir = Filesystem::createTempDir('yarn-release');
+ArtifactArchiver::downloadArtifacts($artifacts, $tempdir);
+
+$release = GitHub::getOrCreateRelease($build->vcs_tag);
+$output = '['.$build->build_num.'] Uploaded to '.$build->vcs_tag.":\n";
+
+$promises = [];
+foreach ($artifacts as $filename => $_) {
+  $path = $tempdir.$filename;
+  $promises[] = GitHub::uploadReleaseArtifact($release, $filename, $path);
+  $output .= $filename."\n";
+
+  // GPG sign all the files that need to be signed
+  if (preg_match(Config::SIGN_FILE_TYPES, $filename)) {
+    file_put_contents($path.'.asc', GPG::sign($path, Config::GPG_RELEASE));
+    $promises[] = GitHub::uploadReleaseArtifact($release, $filename.'.asc', $path.'.asc');
+  }
+}
+$responses = Promise\unwrap($promises);
+
+api_response($output);

--- a/nightly/api/sign_releases.php
+++ b/nightly/api/sign_releases.php
@@ -5,11 +5,8 @@
 
 require(__DIR__.'/../lib/api-core.php');
 
-use Analog\Analog;
 use GuzzleHttp\Client;
 use GuzzleHttp\Promise;
-
-Analog::handler(__DIR__.'/../logs/sign_releases.log');
 
 // Validate auth token
 $auth_token = $_GET['token'] ?? '';

--- a/nightly/lib/CircleCI.php
+++ b/nightly/lib/CircleCI.php
@@ -1,0 +1,93 @@
+<?php
+declare(strict_types=1);
+
+use GuzzleHttp\Client;
+
+/**
+ * Wrapper for CircleCI's API, and utility methods for CircleCI webhooks.
+ *
+ * NOTE: Unfortunately, CircleCI does not provide any way of authenticating
+ * webhook calls (such as a secret authentication token), which is why there is
+ * no method to authenticate the authentication token. Instead, we need to hit
+ * their API to verify that the build is legit.
+ */
+class CircleCI {
+  /**
+   * Gets the build provided in the webhook payload, and verifies that it's a
+   * legit CircleCI build rather than someone maliciously calling the webhook.
+   */
+  public static function getAndValidateBuildFromPayload() {
+    $payload = json_decode(file_get_contents('php://input'));
+    if (empty($payload)) {
+      api_error('400', 'No payload provided');
+    }
+    return static::getAndValidateBuild($payload->payload);
+  }
+
+  /**
+   * Loads the specified build from the CircleCI API And verifies that it's a
+   * legit CircleCI build rather than someone maliciously calling the webhook.
+   */
+  public static function getAndValidateBuild($build) {
+    // First validate the data that was passed in as the payload. If the branch
+    // or repo name is not valid, we can quit early (before calling CircleCI's
+    // API)
+    static::validateBuild($build);
+
+    // Now, load this build from their API and revalidate it, to ensure it's
+    // legit and the client isn't tricking us.
+    $verified_build = static::call(
+      'project/github/%s/%s/%s',
+      Config::ORG_NAME,
+      Config::REPO_NAME,
+      $build->build_num
+    );
+    static::validateBuild($verified_build);
+    return $verified_build;
+  }
+
+  /**
+   * Verifies that the specified CircleCI build is one we care about.
+   */
+  public static function validateBuild($build) {
+    if (
+      $build->branch !== Config::BRANCH ||
+      $build->username !== Config::ORG_NAME ||
+      $build->reponame !== Config::REPO_NAME
+    ) {
+      api_response(sprintf(
+        'Not archiving; this build is not on the correct branch: %s/%s/%s',
+        $build->username,
+        $build->reponame,
+        $build->branch
+      ));
+    }
+
+    $build_num = $build->build_num;
+    if (empty($build_num)) {
+      api_error('400', 'No build number found');
+    }
+    if ($build->status !== 'success' && $build->status !== 'fixed') {
+      api_response(sprintf(
+        'Build #%s in wrong status (%s), not archiving it',
+        $build_num,
+        $build->status
+      ));
+    }
+  }
+
+  /**
+   * Calls the CircleCI API.
+   */
+  public static function call(string $uri, ...$uri_args) {
+    $client = new Client([
+      'base_uri' => 'https://circleci.com/api/v1.1/',
+    ]);
+    $response = $client->get(vsprintf($uri, $uri_args), [
+      'headers' => [
+        'Accept' => 'application/json',
+      ],
+    ]);
+    return json_decode((string)$response->getBody());
+  }
+}

--- a/nightly/lib/CircleCI.php
+++ b/nightly/lib/CircleCI.php
@@ -51,7 +51,10 @@ class CircleCI {
    */
   public static function validateBuild($build) {
     if (
-      $build->branch !== Config::BRANCH ||
+      (
+        $build->branch !== Config::BRANCH &&
+        !preg_match(Config::RELEASE_TAG_FORMAT, $build->vcs_tag ?? '')
+      ) ||
       $build->username !== Config::ORG_NAME ||
       $build->reponame !== Config::REPO_NAME
     ) {
@@ -74,6 +77,21 @@ class CircleCI {
         $build->status
       ));
     }
+  }
+
+  public static function getArtifactsForBuild($build_num) {
+    $artifacts = static::call(
+      'project/github/%s/%s/%s/artifacts',
+      Config::ORG_NAME,
+      Config::REPO_NAME,
+      $build_num
+    );
+    $urls = [];
+    foreach ($artifacts as $artifact) {
+      $filename = basename($artifact->path);
+      $urls[$filename] = $artifact->url;
+    }
+    return $urls;
   }
 
   /**

--- a/nightly/lib/Filesystem.php
+++ b/nightly/lib/Filesystem.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * File system utilities
+ */
+class Filesystem {
+  /**
+   * Creates a temporary directory with a unique name.
+   */
+  public static function createTempDir(string $prefix) {
+    $tempdir = tempnam(sys_get_temp_dir(), $prefix);
+    // tempnam() creates a temp *file*, but we want a temp *directory*.
+    unlink($tempdir);
+    mkdir($tempdir);
+    return $tempdir.'/';
+  }
+}

--- a/nightly/lib/GitHub.php
+++ b/nightly/lib/GitHub.php
@@ -43,15 +43,24 @@ class GitHub {
       );
     } catch (\GuzzleHttp\Exception\TransferException $e) {
       // Release doesn't exist yet, so create a new one
-      return static::post(
-        'repos/%s/%s/releases',
-        [Config::ORG_NAME, Config::REPO_NAME],
-        [
-          'name' => $name,
-          'tag_name' => $name,
-        ]
-      );
+      return static::createRelease($name);
     }
+  }
+
+  public static function createRelease(string $name) {
+    $latest_stable_version = Version::getLatestStableYarnVersion();
+    // Assumes release name is in format "v1.2.3"
+    $new_version = ltrim($name, 'v');
+    $is_stable = Version::isSameMinorVersion($latest_stable_version, $new_version);
+    return static::post(
+      'repos/%s/%s/releases',
+      [Config::ORG_NAME, Config::REPO_NAME],
+      [
+        'prerelease' => !$is_stable,
+        'name' => $name,
+        'tag_name' => $name,
+      ]
+    );
   }
 
   /**

--- a/nightly/lib/GitHub.php
+++ b/nightly/lib/GitHub.php
@@ -53,4 +53,28 @@ class GitHub {
       );
     }
   }
+
+  /**
+   * Upload an artifact to the specific GitHub release. Returns a promise so
+   * multiple files can be uploaded in parallel.
+   */
+  public static function uploadReleaseArtifact(
+    $release,
+    string $filename,
+    string $path
+  ): \GuzzleHttp\Promise\PromiseInterface {
+    $client = new Client();
+    $uri = new \Rize\UriTemplate\UriTemplate();
+    $upload_url = $uri->expand(
+      $release->upload_url,
+      ['name' => $filename]
+    );
+    return $client->postAsync($upload_url, [
+      'body' => fopen($path, 'r'),
+      'headers' => [
+        'Authorization' => 'token '.Config::GITHUB_TOKEN,
+        'Content-Type' => 'application/octet-stream',
+      ],
+    ]);
+  }
 }

--- a/nightly/lib/Version.php
+++ b/nightly/lib/Version.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Versioning utilities.
+ */
+class Version {
+  /**
+   * Gets the version number for the latest stable version of Yarn.
+   */
+  public static function getLatestStableYarnVersion(): string {
+    return trim(file_get_contents('https://yarnpkg.com/latest-version'));
+  }
+
+  /**
+   * Determines if two version numbers are the same minor version.
+   */
+  public static function isSameMinorVersion(string $a, string $b): bool {
+    $a_parts = explode('.', $a);
+    $b_parts = explode('.', $b);
+    return $a_parts[0] === $b_parts[0] && $a_parts[1] === $b_parts[1];
+  }
+}

--- a/nightly/lib/api-core.php
+++ b/nightly/lib/api-core.php
@@ -27,3 +27,6 @@ set_exception_handler(function($exception) {
 	Analog::warning($exception);
 	api_error('500', $exception->getMessage());
 });
+
+// Set log file name based on name of script
+Analog::handler(__DIR__.'/../logs/'.basename($_SERVER['SCRIPT_NAME'], '.php').'.log');


### PR DESCRIPTION
Adds a `/release_circleci` endpoint to the release infra. This is similar to the existing `/release_appveyor` endpoint used for uploading AppVeyor release files. 

It's called as a CircleCI webhook. It validates that the build provided in the payload is a legitimate build in a branch on the Yarn repo, grabs the artifacts, GPG signs them, then uploads them to a GitHub release.

References https://github.com/yarnpkg/yarn/issues/2799