### PR TITLE
Kick off Jenkins build job when release is 'complete' (contains both Linux and Windows artifacts)

### DIFF
--- a/nightly/api/sign_releases.php
+++ b/nightly/api/sign_releases.php
@@ -18,8 +18,8 @@ api_error('403', 'Unauthorized');
 $client = new Client();
 $releases = GitHub::call(
   'repos/%s/%s/releases',
-  Config::ORG_NAME,
-  Config::REPO_NAME
+  Config::RELEASE_ORG_NAME,
+  Config::RELEASE_REPO_NAME
 );
 
 $files_to_sign = [];

--- a/nightly/lib/GitHub.php
+++ b/nightly/lib/GitHub.php
@@ -32,29 +32,29 @@ class GitHub {
     return json_decode((string)$response->getBody());
   }
 
-  public static function getOrCreateRelease(string $name) {
+  public static function getOrCreateRelease(string $name, bool $is_stable) {
     // Check if this release exists
     try {
-      return static::call(
-        'repos/%s/%s/releases/tags/%s',
-        Config::ORG_NAME,
-        Config::REPO_NAME,
-        $name
-      );
+      return static::getRelease($name);
     } catch (\GuzzleHttp\Exception\TransferException $e) {
       // Release doesn't exist yet, so create a new one
-      return static::createRelease($name);
+      return static::createRelease($name, $is_stable);
     }
   }
 
-  public static function createRelease(string $name) {
-    $latest_stable_version = Version::getLatestStableYarnVersion();
-    // Assumes release name is in format "v1.2.3"
-    $new_version = ltrim($name, 'v');
-    $is_stable = Version::isSameMinorVersion($latest_stable_version, $new_version);
+  public static function getRelease(string $name) {
+    return static::call(
+      'repos/%s/%s/releases/tags/%s',
+      Config::RELEASE_ORG_NAME,
+      Config::RELEASE_REPO_NAME,
+      $name
+    );
+  }
+
+  public static function createRelease(string $name, bool $is_stable) {
     return static::post(
       'repos/%s/%s/releases',
-      [Config::ORG_NAME, Config::REPO_NAME],
+      [Config::RELEASE_ORG_NAME, Config::RELEASE_REPO_NAME],
       [
         'prerelease' => !$is_stable,
         'name' => $name,

--- a/nightly/lib/Jenkins.php
+++ b/nightly/lib/Jenkins.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+use GuzzleHttp\Client;
+
+/**
+ * Wrapper for Jenkins' API.
+ */
+class Jenkins {
+  public static function build(string $job, string $token, array $args) {
+    self::call(
+      '/job/%s/buildWithParameters',
+      [$job],
+      array_merge(['token' => $token], $args)
+    );
+  }
+
+  public static function call(string $uri, array $uri_args, array $post_data) {
+    $crumb = self::getCrumb();
+    $client = new Client([
+      'base_uri' => Config::JENKINS_URL,
+    ]);
+    $response = $client->post(vsprintf($uri, $uri_args), [
+      'form_params' => $post_data,
+      'headers' => [
+        $crumb->crumbRequestField => $crumb->crumb,
+      ],
+    ]);
+    return json_decode((string)$response->getBody());
+  }
+
+  /**
+   * The "crumb" is a CSRF token that's required for all POST requests to
+   * Jenkins, including the API.
+   */
+  private static $crumb = null;
+  public static function getCrumb() {
+    if (self::$crumb === null) {
+      $client = new Client([
+        'base_uri' => Config::JENKINS_URL,
+      ]);
+      $response = $client->get('crumbIssuer/api/json');
+      self::$crumb = json_decode((string)$response->getBody());
+    }
+    return self::$crumb;
+  }
+}

--- a/nightly/lib/Release.php
+++ b/nightly/lib/Release.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+use GuzzleHttp\Client;
+
+/**
+ * Utilities for publishing release versions of Yarn
+ */
+class Release {
+  /**
+   * Checks if the specified release is complete (that is, it contains all the
+   * artifacts required by a Yarn release). If so, kicks off some post-release
+   * processing jobs.
+   *
+   * This is required because the Windows build and Linux build are built on two
+   * separate build systems, and they both upload artifacts to GitHub. We can
+   * only finalise the release once all the artifacts have been uploaded.
+   */
+  public static function performPostReleaseJobsIfReleaseIsComplete(string $version): string {
+    $release = GitHub::getRelease('v'.$version);
+
+    // File types that are *required* for a release to be complete
+    $has_file = [
+      '.deb' => false,
+      '.js' => false,
+      '.js.asc' => false,
+      '.msi' => false,
+      '.tar.gz' => false,
+      '.tar.gz.asc' => false,
+    ];
+    foreach ($release->assets as $asset) {
+      foreach ($has_file as $type => $_) {
+        if (Str::endsWith($asset->name, $type)) {
+          $has_file[$type] = true;
+          break;
+        }
+      }
+    }
+
+    // Check if any required files are missing
+    $missing_files = array_filter($has_file, function($exists) {
+      return !$exists;
+    });
+    if (count($missing_files) > 0) {
+      return
+        'Release is not complete yet; these file types are missing: '.
+        implode(', ', array_keys($missing_files));
+    }
+
+    // If we got here, the release must be complete!
+    static::performPostReleaseJobs($version, !$release->prerelease);
+    return 'Release is complete! Post-release jobs scheduled.';
+  }
+
+  /**
+   * Kicks off a Jenkins build to perform any post-release processing (such as
+   * pushing to Chocolatey and Homebrew, bumping the version number on the Yarn
+   * site, etc.)
+   */
+  public static function performPostReleaseJobs(string $version, bool $is_stable) {
+    Jenkins::build(
+      Config::JENKINS_VERSION_JOB,
+      Config::JENKINS_VERSION_TOKEN,
+      [
+        'YARN_VERSION' => $version,
+        'YARN_RC' => $is_stable ? 'false' : 'true',
+        'cause' => 'Automated release of Yarn '.$version,
+      ]
+    );
+  }
+}

--- a/nightly/lib/Version.php
+++ b/nightly/lib/Version.php
@@ -20,4 +20,13 @@ class Version {
     $b_parts = explode('.', $b);
     return $a_parts[0] === $b_parts[0] && $a_parts[1] === $b_parts[1];
   }
+
+  /**
+   * Determines if the specified NEW version number should be considered a
+   * stable release, based on the current stable version number of Yarn.
+   */
+  public static function isStableVersionNumber(string $new_version): bool {
+    $latest_stable_version = static::getLatestStableYarnVersion();
+    return static::isSameMinorVersion($latest_stable_version, $new_version);
+  }
 }

--- a/nightly/lib/api-core.php
+++ b/nightly/lib/api-core.php
@@ -25,7 +25,11 @@ set_error_handler(function($errno, $errstr, $errfile, $errline) {
 });
 set_exception_handler(function($exception) {
 	Analog::warning($exception);
-	api_error('500', $exception->getMessage());
+	$message = $exception->getMessage();
+	if ($exception instanceof \GuzzleHttp\Exception\ClientException) {
+		$message .= "\n\nResponse:\n".$exception->getResponse()->getBody();
+	}
+	api_error('500', $message);
 });
 
 // Set log file name based on name of script

--- a/nightly/lib/config.php
+++ b/nightly/lib/config.php
@@ -7,6 +7,12 @@ class Config {
   const BRANCH = 'master';
   const RELEASE_TAG_FORMAT = '/v[0-9]+(\.[0-9]+)*/';
 
+  // GitHub organization and repository used for releases. This is normally the
+  // same as above, but can be changed for debugging purposes
+  //const RELEASE_ORG_NAME = 'Daniel15Test';
+  const RELEASE_ORG_NAME = Config::ORG_NAME;
+  const RELEASE_REPO_NAME = Config::REPO_NAME;
+
   // Auth token for sign_releases endpoint
   const SIGN_AUTH_TOKEN = 'CHANGEME';
   // File types that should be GPG signed as part of GitHub releases
@@ -18,6 +24,10 @@ class Config {
   const APPVEYOR_USERNAME = 'kittens';
   const APPVEYOR_PROJECT_SLUG = 'yarn';
   const APPVEYOR_WEBHOOK_AUTH_TOKEN = 'Bearer CHANGEME';
+
+  const JENKINS_URL = 'https://build.dan.cx/';
+  const JENKINS_VERSION_JOB = 'yarn-version';
+  const JENKINS_VERSION_TOKEN = 'CHANGEME';
 
   const ARTIFACT_PATH = __DIR__.'/../artifacts/';
   const DEBIAN_INCOMING_PATH = __DIR__.'/../deb-incoming/';


### PR DESCRIPTION
As part of automating the release process. When both the CircleCI (Linux) and AppVeyor (Windows) artifacts have been uploaded to the GitHub release, run the Jenkins job that was added in https://github.com/yarnpkg/yarn/pull/3284.

References https://github.com/yarnpkg/website/issues/471